### PR TITLE
[#34] prettier 를 peerDependencies 로 이동합니다

### DIFF
--- a/.changeset/spotty-months-peel.md
+++ b/.changeset/spotty-months-peel.md
@@ -1,0 +1,6 @@
+---
+"@naverpay/eslint-config": patch
+"@naverpay/prettier-config": major
+---
+
+[#34] prettier 를 peerDependencies 로 이동합니다

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -27,7 +27,6 @@
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-unused-imports": "^3.0.0",
-        "prettier": "^2.8.8",
         "@naverpay/eslint-plugin": "workspace:*"
     },
     "author": "@NaverPayDev/frontend",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -7,6 +7,9 @@
         "version": "pnpm version",
         "deploy": "pnpm publish"
     },
+    "peerDependencies": {
+        "prettier": "^2.8.8 || ^3.0.0"
+    },
     "author": "@NaverPayDev/frontend",
     "repository": {
         "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,9 +109,6 @@ importers:
       eslint-plugin-unused-imports:
         specifier: ^3.0.0
         version: 3.1.0(@typescript-eslint/eslint-plugin@7.9.0)(eslint@8.57.0)
-      prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
 
   packages/eslint-plugin:
     dependencies:
@@ -148,7 +145,11 @@ importers:
         specifier: ^0.32.1
         version: 0.32.1
 
-  packages/prettier-config: {}
+  packages/prettier-config:
+    dependencies:
+      prettier:
+        specifier: ^2.8.8 || ^3.0.0
+        version: 3.2.5
 
   packages/stylelint-config:
     dependencies:
@@ -4810,12 +4811,12 @@ packages:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+    dev: true
 
   /prettier@3.2.5:
     resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
     engines: {node: '>=14'}
     hasBin: true
-    dev: true
 
   /pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}


### PR DESCRIPTION
## Related Issue
[#34] prettier 를 peerDependencies 로 이동합니다

## Describe your changes
- `@naverpay/eslint-config` 의 peerDependencies 에서 `prettier` 제거
- `@naverpay/prettier-config` 의 peerDependencies 에서 `prettier` 추가
+`@naverpay/prettier-config@1.0.0` 버전으로 올립니다.


