### PR TITLE
Add ESLint rule ensuring peerDependencies are also declared in devDependencies

### DIFF
--- a/.changeset/clever-ghosts-smell.md
+++ b/.changeset/clever-ghosts-smell.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/eslint-plugin": minor
+---
+
+Add ESLint rule ensuring peerDependencies are also declared in devDependencies
+
+PR: [Add ESLint rule ensuring peerDependencies are also declared in devDependencies](https://github.com/NaverPayDev/code-style/pull/90)

--- a/packages/eslint-plugin/lib/index.js
+++ b/packages/eslint-plugin/lib/index.js
@@ -2,6 +2,7 @@ import pkg from '../package.json'
 import importServerOnly from './rules/import-server-only'
 import memoReactComponents from './rules/memo-react-components.js'
 import optimizeSvgComponents from './rules/optimize-svg-components.js'
+import peerDepsInDevDeps from './rules/peer-deps-in-dev-deps.js'
 import preventDefaultImport from './rules/prevent-default-import.js'
 import sortExports from './rules/sort-exports.js'
 import svgUniqueId from './rules/svg-unique-id.js'
@@ -18,6 +19,7 @@ const plugin = {
         'sort-exports': sortExports,
         'svg-unique-id': svgUniqueId,
         'import-server-only': importServerOnly,
+        'peer-deps-in-dev-deps': peerDepsInDevDeps,
     },
 }
 

--- a/packages/eslint-plugin/lib/rules/peer-deps-in-dev-deps.js.js
+++ b/packages/eslint-plugin/lib/rules/peer-deps-in-dev-deps.js.js
@@ -1,0 +1,51 @@
+import path from 'path'
+
+export default {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Ensure that all peerDependencies are also declared in devDependencies.',
+            recommended: false,
+        },
+        fixable: null,
+        schema: [],
+        messages: {
+            missingInDevDeps: "'{{packageName}}' is declared in peerDependencies but not in devDependencies.",
+        },
+    },
+
+    create(context) {
+        return {
+            Program(node) {
+                const filename = path.basename(context.getFilename())
+                if (filename !== 'package.json') {
+                    return
+                }
+
+                const sourceCode = context.getSourceCode().getText()
+                let json
+
+                try {
+                    json = JSON.parse(sourceCode)
+                } catch (error) {
+                    // eslint-disable-next-line no-console
+                    console.error('Failed to parse package.json:', error)
+                    return
+                }
+
+                const peerDeps = json.peerDependencies || {}
+                const devDeps = json.devDependencies || {}
+
+                for (const [depName] of Object.entries(peerDeps)) {
+                    if (!Object.prototype.hasOwnProperty.call(devDeps, depName)) {
+                        context.report({
+                            node,
+                            messageId: 'missingInDevDeps',
+                            data: {packageName: depName},
+                        })
+                    }
+                }
+            },
+        }
+    },
+}


### PR DESCRIPTION
## Description

this resolves #82

This pull request adds a new ESLint rule that validates the project's `package.json` to ensure that all dependencies under "peerDependencies" are also declared in "devDependencies". This is important for local development because peer dependencies often need to be present in the developer's environment for builds, tests, and other tooling to work properly.

## Implementation Details

- The rule targets files named `package.json`.
- It parses `package.json` as JSON and compares the keys in `peerDependencies` against those in `devDependencies`.
- If any package is missing from `devDependencies`, an ESLint error is reported for each missing package.
