### PR TITLE
🔧 eslint-config-prettier 패키지 버전 10.1.5에서 10.1.8로 업데이트

### DIFF
--- a/.changeset/spicy-doodles-hide.md
+++ b/.changeset/spicy-doodles-hide.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/eslint-config": patch
+---
+
+🔧 eslint-config-prettier 패키지 버전 10.1.5에서 10.1.8로 업데이트 https://safedep.io/eslint-config-prettier-major-npm-supply-chain-hack/ 보안 취약점 대응
+
+PR: [🔧 eslint-config-prettier 패키지 버전 10.1.5에서 10.1.8로 업데이트](https://github.com/NaverPayDev/code-style/pull/122)

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -47,7 +47,7 @@
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.15.0",
         "@naverpay/eslint-plugin": "workspace:*",
-        "eslint-config-prettier": "^10.1.5",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": ">=2.31.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-n": "^17.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,8 +59,8 @@ importers:
         specifier: workspace:*
         version: link:../eslint-plugin
       eslint-config-prettier:
-        specifier: ^10.1.5
-        version: 10.1.5(eslint@9.17.0)
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@9.17.0)
       eslint-plugin-import:
         specifier: '>=2.31.0'
         version: 2.31.0(@typescript-eslint/parser@8.34.0(eslint@9.17.0)(typescript@5.3.3))(eslint@9.17.0)
@@ -2555,8 +2555,8 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
-  eslint-config-prettier@10.1.5:
-    resolution: {integrity: sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==}
+  eslint-config-prettier@10.1.8:
+    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
@@ -7781,7 +7781,7 @@ snapshots:
       eslint: 9.17.0
       semver: 7.6.3
 
-  eslint-config-prettier@10.1.5(eslint@9.17.0):
+  eslint-config-prettier@10.1.8(eslint@9.17.0):
     dependencies:
       eslint: 9.17.0
 


### PR DESCRIPTION
## Related Issue

https://safedep.io/eslint-config-prettier-major-npm-supply-chain-hack/

## Describe your changes
