### PR TITLE
fix: canary/rc 워크플로우 OIDC 인증 방식으로 전환

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -6,6 +6,10 @@ on:
         types:
             - created
 
+permissions:
+    id-token: write
+    contents: write
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -28,6 +32,14 @@ jobs:
                   node-version: '22'
                   cache: 'pnpm'
 
+            - name: Check and upgrade npm
+              run: |
+                  echo "Current npm version:"
+                  npm --version
+                  npm install -g npm@latest
+                  echo "Upgraded npm version:"
+                  npm --version
+
             - name: Install Dependencies
               run: pnpm install --frozen-lockfile
 
@@ -39,7 +51,6 @@ jobs:
               with:
                   github_token: ${{ secrets.ACTION_TOKEN }} # Add user PAT if necessary
                   npm_tag: canary # Specify the npm tag to use for deployment
-                  npm_token: ${{ secrets.NPM_TOKEN }} # Provide the token required for npm publishing
                   publish_script: pnpm run release:canary # Script to execute Canary deployment
                   packages_dir: packages # Directory of packages to detect changes (default: packages,share)
                   excludes: '.turbo,.github' # Files or directories to exclude from change detection

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -9,6 +9,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
+    id-token: write
     contents: write # to create release
 
 jobs:
@@ -34,6 +35,14 @@ jobs:
                   node-version: '22'
                   cache: 'pnpm'
 
+            - name: Check and upgrade npm
+              run: |
+                  echo "Current npm version:"
+                  npm --version
+                  npm install -g npm@latest
+                  echo "Upgraded npm version:"
+                  npm --version
+
             - name: Install Dependencies
               run: pnpm install --frozen-lockfile
 
@@ -45,7 +54,6 @@ jobs:
               with:
                   github_token: ${{ secrets.ACTION_TOKEN }} # Add user PAT if necessary
                   npm_tag: rc # Specify the npm tag to use for deployment
-                  npm_token: ${{ secrets.NPM_TOKEN }} # Provide the token required for npm publishing
                   publish_script: pnpm run release:canary # Script to execute Canary deployment
                   packages_dir: packages # Directory of packages to detect changes (default: packages,share)
                   excludes: '.turbo,.github' # Files or directories to exclude from change detection


### PR DESCRIPTION
## Related Issue

- https://github.com/NaverPayDev/changeset-actions/pull/29/files

## Describe your changes

- [changeset-actions] npm_token 지원 중단 -> OIDC 전환 작업 대응

> 위 작업의 영향으로 현재 canary/rc 워크플로우가 실패하고 있습니다.
<img width="791" height="96" alt="스크린샷 2026-01-08 오후 6 49 27" src="https://github.com/user-attachments/assets/9f9cb466-cf90-47fc-a6b0-cf6ed10d43fc" />
<img width="929" height="106" alt="스크린샷 2026-01-08 오후 6 49 47" src="https://github.com/user-attachments/assets/e7089e5f-88fc-49f3-8868-d5be106c0256" />


## 기타
release.yml은 용찬님께서 먼저 대응 작업해주셔서 정상 동작하고 있습니다: https://github.com/NaverPayDev/code-style/commit/c7b723b7c19df3b4d99970f15e5c32a7c55b7d8d