### PR TITLE
[#162] oxfmt-config 패키지 추가

### DIFF
--- a/.changeset/oxfmt-config.md
+++ b/.changeset/oxfmt-config.md
@@ -1,0 +1,9 @@
+---
+'@naverpay/code-style-cli': patch
+---
+
+[#162] code-style-cli 에 oxfmt-config 지원 추가
+
+oxfmt 항목을 `@naverpay/oxfmt-config` 설치 + `oxfmt.config.ts` scaffold 방식으로 변경. (oxfmt 는 `extends` 가 없어 `oxfmt.config.ts` 에서 `import config from '@naverpay/oxfmt-config' with {type: 'json'}` 로 사용)
+
+> `@naverpay/oxfmt-config` 패키지(0.0.1)는 첫 배포라 OIDC 가 없어 로컬에서 수동 배포했습니다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ and published. There are two kinds of packages:
   dual CJS/ESM bundles under `dist/`. Their `package.json` `exports` point at `./dist/cjs/...`
   and `./dist/esm/...`, so **the package must be built before its exports resolve**.
 - **Config-only packages** (`prettier-config`, `stylelint-config`, `biome-config`,
-  `oxlint-config`, `editorconfig`, `markdown-lint`, `code-style-cli`) — ship raw config files
+  `oxlint-config`, `oxfmt-config`, `editorconfig`, `markdown-lint`, `code-style-cli`) — ship raw config files
   (`.json`/`.js`) referenced directly by `main`/`exports`/`bin`. No build step, no `dist/`.
 
 The repo **dogfoods its own packages**: the root `eslint.config.mjs` consumes
@@ -33,6 +33,7 @@ read the relevant one before working inside a package.
 | `@naverpay/stylelint-config` | config (rule modules) | [packages/stylelint-config/CLAUDE.md](./packages/stylelint-config/CLAUDE.md) |
 | `@naverpay/prettier-config` | config-only | [packages/prettier-config/CLAUDE.md](./packages/prettier-config/CLAUDE.md) |
 | `@naverpay/biome-config` | config-only | [packages/biome-config/CLAUDE.md](./packages/biome-config/CLAUDE.md) |
+| `@naverpay/oxfmt-config` | config-only | [packages/oxfmt-config/CLAUDE.md](./packages/oxfmt-config/CLAUDE.md) |
 | `@naverpay/oxlint-config` | config-only | [packages/oxlint-config/CLAUDE.md](./packages/oxlint-config/CLAUDE.md) |
 | `@naverpay/editorconfig` | config-only (copied) | [packages/editorconfig/CLAUDE.md](./packages/editorconfig/CLAUDE.md) |
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [@naverpay/oxlint-config](./packages/oxlint-config/README.md): oxlint config 를 제공하는 패키지입니다.
 - [@naverpay/prettier-config](./packages/prettier-config/README.md): Prettier config 를 제공하는 패키지입니다.
 - [@naverpay/biome-config](./packages/biome-config/README.md): Biome config 를 제공하는 패키지입니다.
+- [@naverpay/oxfmt-config](./packages/oxfmt-config/README.md): oxfmt config 를 제공하는 패키지입니다.
 - [@naverpay/stylelint-config](./packages/stylelint-config/README.md): Stylelint config 를 제공하는 패키지입니다.
 - [@naverpay/editorconfig](./packages/editorconfig/README.md): IDE 일관된 코딩 스타일로 작성할 수 있도록 `.editorconfig` 를 제공하는 패키지입니다.
 - [@naverpay/markdown-lint](./packages/markdown-lint/README.md): 마크다운(Markdown) 파일의 스타일을 검사하는 패키지 입니다.

--- a/packages/code-style-cli/CLAUDE.md
+++ b/packages/code-style-cli/CLAUDE.md
@@ -26,6 +26,6 @@ A tool scaffolds its config file via exactly one of three modes:
 ## Adding an installable tool
 
 Append an entry to `TOOLS` in `configs.js` with its npm `packages` and, if it needs a config file,
-one of the three modes above. Note the catalog also offers `oxfmt` (a formatter config scaffold)
-even though there is no `@naverpay/oxfmt` package — `TOOLS` entries are not limited to this repo's
-packages.
+one of the three modes above. `TOOLS` entries are not limited to this repo's packages — `packages`
+may list any npm package (e.g. an entry can install a third-party tool alongside a `@naverpay/*`
+config).

--- a/packages/code-style-cli/configs.js
+++ b/packages/code-style-cli/configs.js
@@ -44,23 +44,11 @@ function getBiomeContent() {
     )
 }
 
-const OXFMTRC_CONTENT = JSON.stringify(
-    {
-        $schema: './node_modules/oxfmt/configuration_schema.json',
-        singleQuote: true,
-        semi: false,
-        useTabs: false,
-        tabWidth: 4,
-        endOfLine: 'lf',
-        bracketSpacing: false,
-        arrowParens: 'always',
-        bracketSameLine: false,
-        printWidth: 120,
-        trailingComma: 'all',
-    },
-    null,
-    4,
-)
+const OXFMT_CONFIG_CONTENT = `import {defineConfig} from 'oxfmt'
+import config from '@naverpay/oxfmt-config' with {type: 'json'}
+
+export default defineConfig(config)
+`
 
 // 패키지 목록
 export const TOOLS = [
@@ -102,7 +90,12 @@ export const TOOLS = [
         configFile: 'biome.json',
         getContent: getBiomeContent,
     },
-    {value: 'oxfmt', packages: ['oxfmt'], configFile: '.oxfmtrc.json', configContent: OXFMTRC_CONTENT},
+    {
+        value: 'oxfmt-config',
+        packages: ['@naverpay/oxfmt-config', 'oxfmt'],
+        configFile: 'oxfmt.config.ts',
+        configContent: OXFMT_CONFIG_CONTENT,
+    },
 ]
 
 export const TOOLS_MAP = Object.fromEntries(TOOLS.map((t) => [t.value, t]))

--- a/packages/oxfmt-config/.oxfmtrc.json
+++ b/packages/oxfmt-config/.oxfmtrc.json
@@ -1,0 +1,12 @@
+{
+    "singleQuote": true,
+    "semi": false,
+    "useTabs": false,
+    "tabWidth": 4,
+    "endOfLine": "lf",
+    "bracketSpacing": false,
+    "arrowParens": "always",
+    "bracketSameLine": false,
+    "printWidth": 120,
+    "trailingComma": "all"
+}

--- a/packages/oxfmt-config/CHANGELOG.md
+++ b/packages/oxfmt-config/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @naverpay/oxfmt-config
+
+## 0.0.1
+
+### Patch Changes
+
+- [#162] oxfmt-config 패키지 추가 (prettier/biome 와 동일한 포매팅 규칙 제공)

--- a/packages/oxfmt-config/CLAUDE.md
+++ b/packages/oxfmt-config/CLAUDE.md
@@ -1,0 +1,43 @@
+# CLAUDE.md — @naverpay/oxfmt-config
+
+NaverPay's [oxfmt](https://oxc.rs/docs/guide/usage/formatter) config (the oxc Rust-based formatter).
+**Config-only** — the package is `.oxfmtrc.json` (`main`/`exports`). No build, no tests. Peer dep:
+`oxfmt@>=0.50.0`.
+
+## Scope: formatter only
+
+By design this **replaces Prettier**, mirroring `@naverpay/prettier-config` and
+`@naverpay/biome-config`: 4-space indent, `printWidth: 120`, `endOfLine: "lf"`, single quotes,
+`semi: false`, `trailingComma: "all"`, `bracketSpacing: false`, `arrowParens: "always"`,
+`bracketSameLine: false`, `useTabs: false`. Keep these in sync with the Prettier/Biome/editorconfig
+packages when changing the house style. The `.oxfmtrc.json` values are exactly what
+`oxfmt --migrate prettier` produces from `@naverpay/prettier-config`.
+
+## Consumption — no `extends`, JS-config import
+
+oxfmt has **no `extends` key** — the maintainers explicitly declined to add one
+([oxc#16394](https://github.com/oxc-project/oxc/issues/16394)), pointing to JS/TS config files as
+the composition mechanism. oxfmt auto-discovers `.oxfmtrc.json`, `.oxfmtrc.jsonc`, and
+`oxfmt.config.ts` (verified: only `oxfmt.config.ts` among the JS/TS forms auto-loads in 0.56.0;
+others like `oxfmt.config.js`/`.mjs` and `.oxfmtrc.ts` do **not**).
+
+So the package is consumed by importing its JSON into an `oxfmt.config.ts`:
+
+```ts
+import {defineConfig} from 'oxfmt'
+import config from '@naverpay/oxfmt-config' with {type: 'json'}
+
+export default defineConfig(config) // or {...config, <overrides>}
+```
+
+This is why the package keeps `exports: {".": "./.oxfmtrc.json"}` — the `with {type: 'json'}` import
+resolves through it. The raw file path
+(`./node_modules/@naverpay/oxfmt-config/.oxfmtrc.json`) also works as a `-c`/`--config` argument for
+JSON-only setups (no local overrides possible that way).
+
+## Gotchas
+
+- The package ships **no `ignorePatterns`** — oxfmt defaults to honoring `.gitignore` /
+  `.prettierignore`; consumers add `ignorePatterns` in their `oxfmt.config.ts` override.
+- The CLI catalog (`@naverpay/code-style-cli` → `configs.js`) scaffolds an `oxfmt.config.ts` that
+  imports this package; the house-style values live only here.

--- a/packages/oxfmt-config/README.md
+++ b/packages/oxfmt-config/README.md
@@ -1,0 +1,109 @@
+# @naverpay/oxfmt-config
+
+네이버페이 스타일 가이드에 맞게 [oxfmt](https://oxc.rs/docs/guide/usage/formatter) formatter 설정을 커스텀하여 제공합니다.
+
+> oxfmt는 oxc(Rust 기반) 포매터로, prettier 를 대체하는 빠른 포매터입니다.
+> `@naverpay/oxfmt-config`는 `@naverpay/prettier-config` · `@naverpay/biome-config`와 동일한 포매팅 규칙을 제공합니다.
+
+## 설치 방법
+
+```bash
+npm install @naverpay/oxfmt-config oxfmt -D
+```
+
+## 사용 방법
+
+> **Note:** oxfmt 는 `extends` 키가 없습니다. ([oxc#16394](https://github.com/oxc-project/oxc/issues/16394)) 대신 메인테이너 권장 방식인 `oxfmt.config.ts` 에서 공유 설정을 import 해서 사용합니다.
+
+프로젝트 루트에 `oxfmt.config.ts` 파일을 생성하고 `@naverpay/oxfmt-config` 를 import 합니다.
+
+```ts
+// oxfmt.config.ts
+import {defineConfig} from 'oxfmt'
+import config from '@naverpay/oxfmt-config' with {type: 'json'}
+
+export default defineConfig(config)
+```
+
+> `defineConfig` 는 선택사항이지만 타입 체크/자동완성을 제공합니다. `with {type: 'json'}` import attribute 로 패키지의 `.oxfmtrc.json` 을 그대로 가져옵니다.
+>
+> 프로젝트 `package.json` 에 `"type": "module"` 이 없으면 Node 가 성능 경고를 출력할 수 있습니다(동작에는 영향 없음). `"type": "module"` 을 추가하면 사라집니다.
+
+### 일부 규칙만 덮어쓰기
+
+공유 설정을 펼친 뒤 원하는 값만 덮어씁니다.
+
+```ts
+// oxfmt.config.ts
+import {defineConfig} from 'oxfmt'
+import config from '@naverpay/oxfmt-config' with {type: 'json'}
+
+export default defineConfig({
+    ...config,
+    printWidth: 80,
+    ignorePatterns: ['dist', 'node_modules'],
+})
+```
+
+> ignore 는 기본적으로 `.gitignore` · `.prettierignore` 를 따르며, 추가로 제외할 경로는 `ignorePatterns` 로 지정합니다.
+
+## CLI
+
+`oxfmt` 는 `oxfmt.config.ts` 를 자동으로 탐색하므로 별도 옵션 없이 실행합니다.
+
+```jsonc
+// package.json
+{
+    "scripts": {
+        "format": "oxfmt --check .",
+        "format:fix": "oxfmt ."
+    }
+}
+```
+
+> 기본 동작은 파일을 직접 수정(`--write`)하는 것이며, `--check` 는 포매팅 여부만 검사합니다.
+
+### JSON 설정만 쓰고 싶다면 (대안)
+
+TS 설정 파일 대신 JSON 만 쓰고 싶다면, `-c`(`--config`) 로 패키지의 설정 파일 경로를 직접 가리킬 수 있습니다. (이 경우 로컬 override 는 불가합니다.)
+
+```jsonc
+// package.json
+{
+    "scripts": {
+        "format": "oxfmt -c ./node_modules/@naverpay/oxfmt-config/.oxfmtrc.json --check ."
+    }
+}
+```
+
+> [lefthook](https://github.com/evilmartians/lefthook)을 사용해서 commit 또는 push 전에 스타일 확인을 자동화할 것을 권장합니다.
+
+## Integrating with IDE
+
+- code-style에서는 **Formatting을 위해 oxfmt** 를, **Code-quality를 위해 oxlint/ESLint** 를 사용할 수 있습니다.
+- IDE에서 autofix 하기 위해 아래 설정이 필요합니다.
+
+### VSCode
+
+1. [oxc Extension](https://marketplace.visualstudio.com/items?itemName=oxc.oxc-vscode)을 설치합니다.
+2. IDE에서 Command Palette(CMD/CTRL + Shift + P)를 열고 `settings.json`을 입력하여 설정파일을 오픈합니다.
+3. 아래 설정을 추가하면 파일 저장시 oxfmt config에 맞게 autofix 할 수 있습니다.
+
+```json
+{
+    "oxc.enable": true,
+    "oxc.fmt.experimental": true,
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.formatOnSave": true,
+    "[typescript]": {
+        "editor.defaultFormatter": "oxc.oxc-vscode"
+    },
+    "[javascript]": {
+        "editor.defaultFormatter": "oxc.oxc-vscode"
+    }
+}
+```
+
+### WebStorm
+
+[oxc-intellij-plugin](https://plugins.jetbrains.com/plugin/27061-oxc)을 설치하여 사용할 수 있습니다.

--- a/packages/oxfmt-config/README.md
+++ b/packages/oxfmt-config/README.md
@@ -35,11 +35,11 @@ export default defineConfig(config)
 
 ```ts
 // oxfmt.config.ts
-import {defineConfig} from 'oxfmt'
+import {defineConfig, type OxfmtConfig} from 'oxfmt'
 import config from '@naverpay/oxfmt-config' with {type: 'json'}
 
 export default defineConfig({
-    ...config,
+    ...(config as OxfmtConfig),
     printWidth: 80,
     ignorePatterns: ['dist', 'node_modules'],
 })

--- a/packages/oxfmt-config/package.json
+++ b/packages/oxfmt-config/package.json
@@ -1,0 +1,34 @@
+{
+    "name": "@naverpay/oxfmt-config",
+    "version": "0.0.1",
+    "description": "oxfmt configuration for NaverPay projects",
+    "keywords": [
+        "oxfmt",
+        "oxc",
+        "config",
+        "formatter",
+        "naverpay"
+    ],
+    "homepage": "https://github.com/NaverPayDev/code-style",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/NaverPayDev/code-style.git",
+        "directory": "packages/oxfmt-config"
+    },
+    "license": "MIT",
+    "author": "@NaverPayDev/frontend",
+    "type": "module",
+    "exports": {
+        ".": "./.oxfmtrc.json"
+    },
+    "main": ".oxfmtrc.json",
+    "files": [
+        ".oxfmtrc.json"
+    ],
+    "devDependencies": {
+        "oxfmt": "^0.56.0"
+    },
+    "peerDependencies": {
+        "oxfmt": ">=0.50.0"
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,12 @@ importers:
         specifier: ^4.0.17
         version: 4.0.17(sass-embedded@1.85.1)(terser@5.36.0)
 
+  packages/oxfmt-config:
+    devDependencies:
+      oxfmt:
+        specifier: ^0.56.0
+        version: 0.56.0
+
   packages/oxlint-config:
     devDependencies:
       oxlint:
@@ -1484,6 +1490,120 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oxfmt/binding-android-arm-eabi@0.56.0':
+    resolution: {integrity: sha512-CSCxi7ovYojgfdPOdUb9T508HKeAdDIKeRGg7x8IZwVJrWz9gVgX7MbUnFqtQAE4QvoNo07mj2JlwnOzJw4qqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.56.0':
+    resolution: {integrity: sha512-HYJFnd+PkDwf6S9ZPGzXXtjNqvRWFnnhdbWaouh4mi/SxU8wmDuzlMn3xo/wDTGnr4Q1VA7ZzOaE/D4biW0W6A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.56.0':
+    resolution: {integrity: sha512-sftR/bEOr+t1gs+evwsHi/Xbq2FAPA2uU3VMr8n6ZU9PoK/IMSfnfu7+OEe/uy1+knhrFl4Wvy7Vkm3uo9mJ7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.56.0':
+    resolution: {integrity: sha512-z66SdjLqa3MUPKvTp3Mbb5nSjKSbnYxJGeB+Wx987s8T5hPcIRiBMfnJ6zcPgYtQn3x5xjvdzNVkXrSeYH6ZFg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.56.0':
+    resolution: {integrity: sha512-t2tkrV1vtZyaItSQ71dTi2ZVKZEI39b/LqLT12V5KMfIeXK6N32TUC1jhOXKVQmhECq9j2ZXMQV3JeT1kh9Vmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.56.0':
+    resolution: {integrity: sha512-+gCy+Tp3RHeXQ9y/QrS76lXIpZkbziTyp6hIgjB2MssCwfMph3vG/GEfkhO34Rai1vhYIaUkvv8UT1BcDorJPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.56.0':
+    resolution: {integrity: sha512-0kKkVvQ2I+FJ2sxQyUu1zJ0yWP5kcWse/yVFnGQSFCXMwSSkfEaUGu0dW774O7nyy3jrcBGap7OSc8dZmU/CdA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.56.0':
+    resolution: {integrity: sha512-npkA2siMbyWRh+wEhi1aTAx4RirukGcGNt8V4Ch86pG+xU9aurqS1MZOnKYMu03ISwat3rB6zkQx51SsB9obNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-musl@0.56.0':
+    resolution: {integrity: sha512-UekqOjGkV4/MkqreCV9SPIB2jlR3/HbXrmhV1rVXJZ9wfDXMyCMriLtq3tHqLY4PkbVWNtfcm1kMojJ26KLSJw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.56.0':
+    resolution: {integrity: sha512-XSzveSpeZMD5XJpew5lRFVtNnT04xd3rJxENXmk7wkZzN9oWzv2aFJyoNDhOtoz69BYaS/fg4SYl+CfEZRpB0Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.56.0':
+    resolution: {integrity: sha512-EkQ0nJa7k7HDDIVuPF7WY+k4k+bzdclLYtyIXNt7/OqVghfNiMym6YGppFBgx1XRIHW6QylxBz5OogumPjPJbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.56.0':
+    resolution: {integrity: sha512-dyjAGW8jKRge0ik6U/dgvQG0nVpA3iBlRskQTz5qJLvQWIrySxX5jpqzPetLBNIIZ231KA82fDdi1nLTk8ENCw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.56.0':
+    resolution: {integrity: sha512-60ZGH3LtfqlW8X6vcLdSFY4lvCQYINurttYBKaALnHCDVAUCYJ1LsUgS6p1XOzVlzEDx3yNUZvDF1Lvt59zoZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxfmt/binding-linux-x64-gnu@0.56.0':
+    resolution: {integrity: sha512-u1suj1tgJHK4ZqB7buCtdbNef2n8+d0lXTPJwLHNmtyK6p+DTpsaoDvmqhQrA56fgKYv4LuRxNtL8YooebKOew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-x64-musl@0.56.0':
+    resolution: {integrity: sha512-aYGLvlQHt80y+qKEtfJY/Nm27G0125Lv+qyh9SJ4Cjc6lXnXjD+ndfhqQnbV24POpMi7rNRi0jvx/0d70FRpCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/binding-openharmony-arm64@0.56.0':
+    resolution: {integrity: sha512-H/re/gO+7ysVc+kywHNuzY3C33EN9sQcZhg0kp1ZwOZl7y998ZE5mhnBiuGR/nYI0pqLL5xQfrHVUOJ/cIJsCA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.56.0':
+    resolution: {integrity: sha512-6qLNXfXmtAs8jXDvYMkxk6Wec5SUJoew+ZX1uOZmqaR7ks0EJFbAohuOCELDyJMWyVlxotVG8Xf8m74Bfq0O2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.56.0':
+    resolution: {integrity: sha512-UXEXuKphAe15bsob4AswNMArCw38XSmUIs3wk1s6e6MX9OWGW/IRWU95s1hZDiVg09STy1jHgyN2qkqbu1FT0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.56.0':
+    resolution: {integrity: sha512-HPyNDjky+NIOuaMvHZflR+kst3YWdUOH2JUQYkf99grqZ5mEBTQM6h9iGy501Z8Xt5xMScrwHOuVCOlqDrktRw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@oxlint/darwin-arm64@1.33.0':
     resolution: {integrity: sha512-PmEQDLHAxiAdyttQ1ZWXd+5VpHLbHf3FTMJL9bg5TZamDnhNiW/v0Pamv3MTAdymnoDI3H8IVLAN/SAseV/adw==}
@@ -3552,6 +3672,19 @@ packages:
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
+  oxfmt@0.56.0:
+    resolution: {integrity: sha512-9Dv0wV3zKiyvhjD7bRKaInKmHQ1sPx3RGOjQkGFJbbdQ16576yf8qhMSO9Q9cvHcs+1NpBsRTkuDDYFFPTJ6gw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
+
   oxlint@1.33.0:
     resolution: {integrity: sha512-4WCL0K8jiOshwJ8WrVk35VAuVaZHC0iX6asjKsrENOrynkAAGcTLLx0Urf0eXZ1Tq7r+qAe3Z9EyHMFPzVyUkg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4340,6 +4473,10 @@ packages:
   tinypool@1.0.2:
     resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
     engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
@@ -6173,6 +6310,63 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@oxfmt/binding-android-arm-eabi@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.56.0':
+    optional: true
 
   '@oxlint/darwin-arm64@1.33.0':
     optional: true
@@ -8412,6 +8606,30 @@ snapshots:
 
   outdent@0.5.0: {}
 
+  oxfmt@0.56.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.56.0
+      '@oxfmt/binding-android-arm64': 0.56.0
+      '@oxfmt/binding-darwin-arm64': 0.56.0
+      '@oxfmt/binding-darwin-x64': 0.56.0
+      '@oxfmt/binding-freebsd-x64': 0.56.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.56.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.56.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.56.0
+      '@oxfmt/binding-linux-arm64-musl': 0.56.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.56.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.56.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.56.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.56.0
+      '@oxfmt/binding-linux-x64-gnu': 0.56.0
+      '@oxfmt/binding-linux-x64-musl': 0.56.0
+      '@oxfmt/binding-openharmony-arm64': 0.56.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.56.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.56.0
+      '@oxfmt/binding-win32-x64-msvc': 0.56.0
+
   oxlint@1.33.0:
     optionalDependencies:
       '@oxlint/darwin-arm64': 1.33.0
@@ -9224,6 +9442,8 @@ snapshots:
       picomatch: 4.0.3
 
   tinypool@1.0.2: {}
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@1.2.0: {}
 


### PR DESCRIPTION
## Related Issue

- #162

## Describe your changes

### Summary

oxfmt(oxc formatter) 공유 설정을 제공하는 `@naverpay/oxfmt-config` 패키지를 추가합니다. `@naverpay/prettier-config` · `@naverpay/biome-config` 와 동일한 포매팅 규칙을 제공합니다.

### Changes

- `@naverpay/oxfmt-config` 신규 패키지 추가 — `.oxfmtrc.json` (4-space, `printWidth: 120`, single quote, `semi: false`, `trailingComma: all`, `bracketSpacing: false`, `arrowParens: always`, `endOfLine: lf`). 값은 `oxfmt --migrate prettier` 가 `@naverpay/prettier-config` 로부터 생성하는 결과와 동일.
- oxfmt 는 `extends` 키가 없어([oxc#16394](https://github.com/oxc-project/oxc/issues/16394) 결론), `oxfmt.config.ts` 에서 `import config from '@naverpay/oxfmt-config' with {type: 'json'}` 로 사용하는 방식 채택.
- `@naverpay/code-style-cli`: oxfmt 항목을 `@naverpay/oxfmt-config` 설치 + `oxfmt.config.ts` scaffold 방식으로 변경.
- 루트 `README.md` / `CLAUDE.md` 패키지 목록에 추가.
- changeset 추가 (`@naverpay/code-style-cli` patch).

### Note

- `@naverpay/oxfmt-config@0.0.1` 은 첫 배포라 OIDC(trusted publishing)가 없어 **패스키 사용 가능한 환경에서 로컬 수동 배포 예정** (현재 미배포). 그래서 changeset 에는 `code-style-cli` 만 포함했습니다.
