### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/oxfmt-config.md
+++ b/.changeset/oxfmt-config.md
@@ -1,9 +1,0 @@
----
-'@naverpay/code-style-cli': patch
----
-
-[#162] code-style-cli 에 oxfmt-config 지원 추가
-
-oxfmt 항목을 `@naverpay/oxfmt-config` 설치 + `oxfmt.config.ts` scaffold 방식으로 변경. (oxfmt 는 `extends` 가 없어 `oxfmt.config.ts` 에서 `import config from '@naverpay/oxfmt-config' with {type: 'json'}` 로 사용)
-
-> `@naverpay/oxfmt-config` 패키지(0.0.1)는 첫 배포라 OIDC 가 없어 로컬에서 수동 배포했습니다.

--- a/packages/code-style-cli/CHANGELOG.md
+++ b/packages/code-style-cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @naverpay/code-style-cli
 
+## 0.1.1
+
+### Patch Changes
+
+- 10b922c: [#162] code-style-cli 에 oxfmt-config 지원 추가
+
+  oxfmt 항목을 `@naverpay/oxfmt-config` 설치 + `oxfmt.config.ts` scaffold 방식으로 변경. (oxfmt 는 `extends` 가 없어 `oxfmt.config.ts` 에서 `import config from '@naverpay/oxfmt-config' with {type: 'json'}` 로 사용)
+
+  > `@naverpay/oxfmt-config` 패키지(0.0.1)는 첫 배포라 OIDC 가 없어 로컬에서 수동 배포했습니다.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/code-style-cli/package.json
+++ b/packages/code-style-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/code-style-cli",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "NaverPay code-style CLI tool",
     "keywords": [
         "code-style",


### PR DESCRIPTION
# Releases
## @naverpay/code-style-cli@0.1.1

### Patch Changes

-   10b922c: [#162] code-style-cli 에 oxfmt-config 지원 추가

    oxfmt 항목을 `@naverpay/oxfmt-config` 설치 + `oxfmt.config.ts` scaffold 방식으로 변경. (oxfmt 는 `extends` 가 없어 `oxfmt.config.ts` 에서 `import config from '@naverpay/oxfmt-config' with {type: 'json'}` 로 사용)

    > `@naverpay/oxfmt-config` 패키지(0.0.1)는 첫 배포라 OIDC 가 없어 로컬에서 수동 배포했습니다.
